### PR TITLE
Fix checking phpunit existence with :command option

### DIFF
--- a/lib/guard/phpunit.rb
+++ b/lib/guard/phpunit.rb
@@ -18,7 +18,8 @@ module Guard
       :all_after_pass => true,
       :keep_failed    => true,
       :cli            => nil,
-      :tests_path     => Dir.pwd
+      :tests_path     => Dir.pwd,
+      :command        => 'phpunit'
     }
 
     # Initialize Guard::PHPUnit.
@@ -30,6 +31,7 @@ module Guard
     # @option options [Boolean] :keep_failed remember failed tests or not
     # @option options [String] :cli The CLI arguments passed to phpunit
     # @option options [String] :tests_path the path where all tests exist
+    # @option options [String] :command the path of phpunit
     #
     def initialize(watchers = [], options = {})
       defaults = DEFAULT_OPTIONS.clone

--- a/lib/guard/phpunit/runner.rb
+++ b/lib/guard/phpunit/runner.rb
@@ -30,7 +30,7 @@ module Guard
 
           return false if paths.empty?
 
-          unless phpunit_exists?
+          unless phpunit_exists?(options)
             UI.error('phpunit is not installed on your machine.', :reset => true)
             return false
           end
@@ -43,10 +43,11 @@ module Guard
         # Checks that phpunit is installed on the user's
         # machine.
         #
+        # @param (see PHPUnit#initialize)
         # @return [Boolean] The status of phpunit
         #
-        def phpunit_exists?
-          `phpunit --version`
+        def phpunit_exists?(options)
+          `#{options[:command]} --version`
           true
         rescue Errno::ENOENT
           false

--- a/spec/guard/phpunit_spec.rb
+++ b/spec/guard/phpunit_spec.rb
@@ -23,6 +23,10 @@ describe Guard::PHPUnit do
       it 'sets a default :tests_path option' do
         subject.options[:tests_path].should == @project_path.to_s
       end
+
+      it 'sets a default :command option' do
+        subject.options[:command].should == 'phpunit'
+      end
     end
 
     context 'when other options are provided' do
@@ -31,7 +35,8 @@ describe Guard::PHPUnit do
                                           :all_after_pass => false,
                                           :keep_failed    => false,
                                           :cli            => '--colors',
-                                          :tests_path     => 'tests'     }) }
+                                          :tests_path     => 'tests',
+                                          :command        => './bin/phpunit' }) }
 
       it 'sets :all_on_start with the provided option' do
         subject.options[:all_on_start].should be_false
@@ -51,6 +56,10 @@ describe Guard::PHPUnit do
 
       it 'sets :tests_path with the provided option' do
         subject.options[:tests_path].should == 'tests'
+      end
+
+      it 'sets :command the provided option' do
+        subject.options[:command].should == './bin/phpunit'
       end
     end
 


### PR DESCRIPTION
This change fix a problem `Guard::PHPUnit::Runner#phpunit_exists?` returns fail with `:command` option due to the method uses `phpunit` literal string. With this change, that now uses :command option.
